### PR TITLE
Fix output typo

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -35,7 +35,7 @@ output "subnet_ids" {
 
 output "subnet_address_prefixes" {
   description = "List of address prefix for subnets"
-  value       = flatten(concat([for s in azurerm_subnet.snet : s.address_prefix], [var.gateway_subnet_address_prefix != null ? azurerm_subnet.gw_snet.0.address_prefixes : null], [var.firewall_subnet_address_prefix != null ? azurerm_subnet.fw-snet.0.address_prefixes : null]))
+  value       = flatten(concat([for s in azurerm_subnet.snet : s.address_prefixes], [var.gateway_subnet_address_prefix != null ? azurerm_subnet.gw_snet.0.address_prefixes : null], [var.firewall_subnet_address_prefix != null ? azurerm_subnet.fw-snet.0.address_prefixes : null]))
 }
 
 output "network_security_group_ids" {


### PR DESCRIPTION
Issue:
address_prefix in azurerm_subnet is deprecated. (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet)

Fix: 
change to address_prefixes.